### PR TITLE
Enforce Keycloak Security Controls

### DIFF
--- a/projects/keycloak/secure-app-realm.json
+++ b/projects/keycloak/secure-app-realm.json
@@ -3,7 +3,18 @@
    "realm":"secure-app",
    "enabled":true,
    "sslRequired":"external",
-   "registrationAllowed":true,
+   "bruteForceProtected" : true,
+   "maxFailureWaitSeconds" : 900,
+   "minimumQuickLoginWaitSeconds" : 60,
+   "waitIncrementSeconds" : 60,
+   "quickLoginCheckMilliSeconds" : 1000,
+   "maxDeltaTimeSeconds" : 43200,
+   "failureFactor" : 5,
+   "eventsEnabled" : true,
+   "eventsListeners" : [ "jboss-logging" ],
+   "enabledEventTypes" : [ "SEND_RESET_PASSWORD", "UPDATE_TOTP", "REMOVE_TOTP", "REVOKE_GRANT", "LOGIN_ERROR", "CLIENT_LOGIN", "RESET_PASSWORD_ERROR", "IMPERSONATE_ERROR", "CODE_TO_TOKEN_ERROR", "CUSTOM_REQUIRED_ACTION", "RESTART_AUTHENTICATION", "UPDATE_PROFILE_ERROR", "IMPERSONATE", "LOGIN", "UPDATE_PASSWORD_ERROR", "CLIENT_INITIATED_ACCOUNT_LINKING", "REGISTER", "LOGOUT", "CLIENT_REGISTER", "IDENTITY_PROVIDER_LINK_ACCOUNT", "UPDATE_PASSWORD", "FEDERATED_IDENTITY_LINK_ERROR", "CLIENT_DELETE", "IDENTITY_PROVIDER_FIRST_LOGIN", "VERIFY_EMAIL", "CLIENT_DELETE_ERROR", "CLIENT_LOGIN_ERROR", "RESTART_AUTHENTICATION_ERROR", "REMOVE_FEDERATED_IDENTITY_ERROR", "EXECUTE_ACTIONS", "SEND_IDENTITY_PROVIDER_LINK_ERROR", "EXECUTE_ACTION_TOKEN_ERROR", "SEND_VERIFY_EMAIL", "EXECUTE_ACTIONS_ERROR", "REMOVE_FEDERATED_IDENTITY", "IDENTITY_PROVIDER_POST_LOGIN", "IDENTITY_PROVIDER_LINK_ACCOUNT_ERROR", "UPDATE_EMAIL", "REGISTER_ERROR", "REVOKE_GRANT_ERROR", "LOGOUT_ERROR", "UPDATE_EMAIL_ERROR", "EXECUTE_ACTION_TOKEN", "CLIENT_UPDATE_ERROR", "UPDATE_PROFILE", "FEDERATED_IDENTITY_LINK", "CLIENT_REGISTER_ERROR", "SEND_VERIFY_EMAIL_ERROR", "SEND_IDENTITY_PROVIDER_LINK", "RESET_PASSWORD", "CLIENT_INITIATED_ACCOUNT_LINKING_ERROR", "REMOVE_TOTP_ERROR", "VERIFY_EMAIL_ERROR", "SEND_RESET_PASSWORD_ERROR", "CLIENT_UPDATE", "IDENTITY_PROVIDER_POST_LOGIN_ERROR", "CUSTOM_REQUIRED_ACTION_ERROR", "UPDATE_TOTP_ERROR", "CODE_TO_TOKEN", "IDENTITY_PROVIDER_FIRST_LOGIN_ERROR" ],
+   "adminEventsEnabled" : true,
+   "adminEventsDetailsEnabled" : true,
    "requiredCredentials":[
       "password"
    ],
@@ -26,9 +37,7 @@
          "attributes":{
 
          },
-         "groups":[
-
-         ]
+        "groups" : [ "/Mobile Users" ]
       },
       {
          "username":"user2",
@@ -48,9 +57,59 @@
          "attributes":{
 
          },
-         "groups":[
+         "groups" : [ "/Mobile Users" ]
+      },
+      {
+         "username":"secure-user",
+         "enabled" : true,
+          "emailVerified" : true,
+          "firstName" : "Secure",
+          "lastName" : "User",
+          "email" : "secure-user@feedhenry.org",
+         "credentials":[
+            {
+               "type":"password",
+               "value":"123"
+            }
+         ],
+         "requiredActions" : [ "CONFIGURE_TOTP" ],
+         "realmRoles" : [ "mobile-user" ],
+         "clientRoles":{
+            "account":[
+               "view-profile",
+               "manage-account"
+            ]
+         },
+         "attributes":{
 
-         ]
+         },
+         "groups" : [ "/Mobile Users" ]
+      },
+      {
+         "username":"secure-user2",
+         "enabled" : true,
+          "emailVerified" : true,
+          "firstName" : "Secure",
+          "lastName" : "User 2",
+          "email" : "secure-user2@feedhenry.org",
+         "credentials":[
+            {
+               "type":"password",
+               "value":"123"
+            }
+         ],
+         "requiredActions" : [ "CONFIGURE_TOTP" ],
+         "realmRoles" : [ "mobile-user" ],
+         "clientRoles":{
+            "account":[
+               "view-profile",
+               "manage-account"
+            ]
+         },
+         "attributes":{
+
+         },
+         "groups" : [ "/Mobile Users" ]
       }
    ],
    "clients":[
@@ -88,6 +147,15 @@
          }
       ]
    },
+   "groups" : [ {
+     "id" : "99cc1e2a-ebde-4cab-893e-58a6f184060c",
+     "name" : "Mobile Users",
+     "path" : "/Mobile Users",
+     "attributes" : { },
+     "realmRoles" : [ "mobile-user" ],
+     "clientRoles" : { },
+     "subGroups" : [ ]
+   } ],
    "roles":{
       "client":{
          "api-server":[


### PR DESCRIPTION
This will help enforce some security controls on the Keycloak server:

- Added Groups for the Mobile Users for better practice for managing user roles.
- Added secure-user and secure-user2 both with 2FA enforced using OTP.
- Added audit tracing/login of Admin and Login/Token Exchange/Access events.
- Added Brute Force Detection with a Temporary Lockout (Permanent lockout is probably a better idea, but the Keycloak image used is older and doesn't support that feature - [Jira ticket](https://issues.jboss.org/browse/FH-4182) created)
- Removed user registration option.

Password Policy has been omitted due to some null pointer issue on import - following up with the keycloak team.