### PR TITLE
 ⬆ update keycloak to 3.3.0.CR2

### DIFF
--- a/projects/openshift/api-server.json
+++ b/projects/openshift/api-server.json
@@ -89,7 +89,7 @@
                     "spec": {
                         "containers": [{
                             "name": "keycloak-openshift",
-                            "image": "docker.io/jimmidyson/keycloak-openshift:2.5.4.Final",
+                            "image": "docker.io/jboss/keycloak-openshift:latest",
                             "ports": [{
                                 "containerPort": 8080,
                                 "protocol": "TCP"


### PR DESCRIPTION
The latest version of keycloak is deployed here: http://keycloak-openshift-mobile-security.osm1.skunkhenry.com/auth/admin/master/console/#/server-info

ping @TommyJ1994 