### PR TITLE
 📝 update instructions to use dnsmasq instead of manually modifying the

### DIFF
--- a/projects/client-certificate-authentication.md
+++ b/projects/client-certificate-authentication.md
@@ -1,6 +1,6 @@
 # Use Client Certificate Authentication
 
-Here are the steps to perform user authentication using X509 client certificate authentication on an Android emulator:
+Here are the steps to perform user authentication using X509 client certificate authentication on an Android device:
 
 ## Step 1: Import the self-signed CA file to the keychain of your local machine
 
@@ -41,13 +41,39 @@ Here are the steps to perform user authentication using X509 client certificate 
 
 * If you have the Keycloak running before, make sure deleting the existing `secure-app` realm first.
 * Run `docker-compose up` and wait for all the services to be up and running.
-* Add the following entry to the `hosts` file:
-```
-127.0.0.1 www.rhdev.me rhdev.me
-```
-* Open a browser window and go to `https://www.rhdev.me:9443`. You should see the Keycloak landing page and the SSL certificate is trusted by the browser. You can login to Keycloak using the default credential `admin/admin`.
 
-## Step 4: Install the CA file and the user certificate on the emulator
+## Step 4: Setup a local DNS server using dnsmasq
+
+The instructions here are for macOS only, but dnsmasq works on Linux as well.
+
+* Install dnsmasq using homebrew
+
+  ```
+  brew install dnsmasq
+  ```
+
+* Edit the configuration file of dnsmasq (should be located here: `/usr/local/etc/dnsmasq.conf`) and add the following line:
+
+  ```
+  # Replace the ip address to the ip address of your local machine
+  address=/rhdev.me/10.32.241.226
+  ```
+
+* Start dnsmasq
+
+  ```
+  sudo brew services start dnsmasq 
+  ```
+
+* Update the DNS server of your host machine to use the dnsmasq service. You can do this in `System Preferences -> Network -> Advanced -> DNS`. Add the ip address of your host machien as the first DNS server. 
+* To verify, open a browser window and go to `https://www.rhdev.me:9443`. You should see the Keycloak landing page and the SSL certificate is trusted by the browser. You can login to Keycloak using the default credential `admin/admin`.
+* Add dnsmasq as the DNS server on the device:
+  * If you are using an Android emulator running on the same machine, you don't need to do anything if the host machine's DNS server entry is updated.
+  * If you are using an Android device, you will need to change the the DNS settings by following the instructions [here](http://xslab.com/2013/08/how-to-change-dns-settings-on-android/). You also need to make sure the device and your local machine are using the same network.
+
+## Step 5: Install the CA file and the user certificate on the Android device
+
+### On an Android emulator
 
 * Start the Android emulator, please make sure the Android emulator is created from a Google API target image (not Google Play images).
 * In the Android Studio, select `Tools -> Android -> Android Device Monitor`
@@ -58,35 +84,10 @@ Here are the steps to perform user authentication using X509 client certificate 
 * In the emulator, click on `Settings -> Search`, type in certificate. You should see there is an option to `Install from SD card`. Select it and select it again.
 * You can then open files from `Android SDK built for x86` folder. You should see the CA file and user certificate file we just uploaded. Click on them to import.
 
-## Step 5: Update the host file of the emulator to add the DNS entry
+### On an Android device
 
-* Restart the emulator to make sure it is writable:
-  
-  ```
-  cd $ANDROID_SDK/tools
-  ./emulator -writable-system -netdelay none -netspeed full -avd <AVD name>
-  cd $ANDROID_SDK/platform-tools
-  ./adb root
-  ./adb remount
-  ```
-
-* Then pull down the hosts file from the emulator
-  
-  ```
-  adb pull /system/etc/hosts ./
-  ```
-
-* Edit the `hosts` file and add an entry to map `www.rhdev.me` to the IP address of your local machine, for example:
-  
-  ```
-  10.201.82.212 www.rhdev.me
-  ```
-
-* Push the hosts file to the emulator again
-  
-  ```
-  adb push ./hosts /system/etc
-  ```
+* If you have an email account on the device, just email the CA file and the p12 file as attachments to the device. You can open them on the device, and you will be prompted to install them.
+* Otherwise, you can copy the CA file and p12 to a SD card, and insert it into the device. On the device, click on `Settings -> Search`, type in certificate. You should see there is an option to `Install from SD card`. Use the option to install the certs.
 
 ## Step 6: Verify you can access the Keycloak server from the emulator
 
@@ -100,7 +101,7 @@ Here are the steps to perform user authentication using X509 client certificate 
 
 ## Step 8: Run the sample app and perform authentication
 
-* Run the sample Android app from the emulator. Perform authentication.
+* Run the sample Android app. Perform authentication.
 * When the system browser is loaded, you should be see that the certificate is loaded into the browser automatically.
 * Continue and you should logged in succesfully from the app.
 


### PR DESCRIPTION
 hosts file

Improve the process by using dnsmasq as the DNS server. It makes the process simpler, as no more requirement to change the hosts file on the device. It also makes it possible to work on a real device.

ping @TommyJ1994 